### PR TITLE
[Solve] 백트래킹, DFS - 알파벳

### DIFF
--- a/yoongyeong/by_kotlin/src/main/kotlin/backTracking_recursion/B1987.kt
+++ b/yoongyeong/by_kotlin/src/main/kotlin/backTracking_recursion/B1987.kt
@@ -1,0 +1,47 @@
+package backTracking_recursion
+
+import java.util.StringTokenizer
+
+// 알파벳
+
+private var r = 0
+private var c = 0
+private lateinit var alphabet: Array<CharArray>
+private val stepR = arrayOf(1, -1, 0, 0)
+private val stepC = arrayOf(0, 0, 1, -1)
+
+private val visited = BooleanArray(26)
+private var maximum = Int.MIN_VALUE
+
+fun main() {
+    val br = System.`in`.bufferedReader()
+    with(StringTokenizer(br.readLine())) {
+        r = nextToken().toInt()
+        c = nextToken().toInt()
+    }
+
+    alphabet = Array(r) { br.readLine().toCharArray() }
+
+    visited[alphabet[0][0] - 'A'] = true
+    dfs()
+    print(maximum)
+
+}
+
+private fun dfs(i: Int = 0, j: Int = 0, cnt: Int = 1) {
+    maximum = maxOf(maximum, cnt)
+
+    for (step in 0 until 4) {
+        val nextR = stepR[step] + i
+        val nextC = stepC[step] + j
+        if (nextR in 0 until r && nextC in 0 until c ) {
+            val charIdx = alphabet[nextR][nextC]-'A'
+            if (!visited[charIdx]) {
+                visited[charIdx] = true
+                dfs(nextR, nextC, cnt+1)
+                visited[charIdx] = false
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
사용한 알고리즘 : DFS, 백트래킹
시간 : 832ms, 메모리 : 14156KB

그래프 탐색을 하면서 이동한 칸에 적혀있던 알파벳이 중복되면 안되므로 visited 배열을 두어 알파벳의 중복이 없도록 탐색하였습니다.
전형적인 DFS, 백트래킹 문제네용..