### PR TITLE
[Solve] 12주차 자유 문제 풀이

### DIFF
--- a/suho/withkotlin/src/main/kotlin/week12/b13334/B13334.kt
+++ b/suho/withkotlin/src/main/kotlin/week12/b13334/B13334.kt
@@ -1,0 +1,59 @@
+package baekjoon.b13334
+
+import java.util.*
+
+/*
+플랫폼 : 백준
+문제번호 : 13334
+문제제목 : 철로
+난이도 : 골드 2
+제한사항 : 1초/512MB
+알고리즘 분류 : 자료 구조, 정렬, 스위핑, 우선순위 큐
+
+알고리즘 설명
+1. 입력을 왼쪽 끝 점 - 오른쪽 끝 점 형태로 넣고
+2. 오른쪽 끝 점을 기준으로 정렬, 같은 경우 왼쪽 끝 점이 작은 순으로
+3. 라인을 하나씩 보면서 길이가 d이하이면 우선순위 큐에 왼쪽 끝 점을 넣는다.
+4. 우선순위 큐에 원소가 존재한다면 길이를 넘어가는 왼쪽 끝 점을 모두 빼준다.
+5. 우선순퀴 큐의 크기로 정답 갱신
+
+채점 결과 : 844ms/55460KB
+풀이 날짜 : 2022/04/11
+*/
+
+private val br = System.`in`.bufferedReader()
+private val bw = System.out.bufferedWriter()
+
+fun main() {
+    val n = br.readLine().toInt()
+    val lines = mutableListOf<Pair<Int, Int>>()
+    repeat(n) {
+        with(StringTokenizer(br.readLine())) {
+            val a = nextToken().toInt()
+            val b = nextToken().toInt()
+
+            lines.add(minOf(a, b) to maxOf(a, b))
+        }
+    }
+    val d = br.readLine().toInt()
+
+    lines.sortWith(compareBy({ it.second }, { it.first }))
+    val pq = PriorityQueue<Int>()
+    var answer = 0
+    lines.forEach {
+        if (it.second - it.first <= d) pq.offer(it.first)
+        else return@forEach
+
+        while (pq.isNotEmpty()) {
+            val front = pq.peek()
+            if (it.second - front > d) pq.poll()
+            else break
+        }
+
+        answer = maxOf(answer, pq.size)
+    }
+
+    bw.write("$answer")
+    bw.close()
+    br.close()
+}

--- a/suho/withkotlin/src/main/kotlin/week12/b2357/B2357.kt
+++ b/suho/withkotlin/src/main/kotlin/week12/b2357/B2357.kt
@@ -1,0 +1,122 @@
+package baekjoon.b2357
+
+import java.util.*
+
+/*
+플랫폼 : 백준
+문제번호 : 2357
+문제제목 : 최솟값과 최댓값
+난이도 : 골드 1
+제한사항 : 2초/196MB
+알고리즘 분류 : 자료 구조, 세그먼트 트리
+
+알고리즘 설명
+세그먼트 트리가 구간 합에 대한 트리인데, 구간 합 대신 구간 최솟값, 최대값을 저장
+
+채점 결과 : 712ms/71700KB
+풀이 날짜 : 2022/04/13
+*/
+
+private val br = System.`in`.bufferedReader()
+private val bw = System.out.bufferedWriter()
+
+fun main() {
+    val n: Int
+    val m: Int
+    with(StringTokenizer(br.readLine())) {
+        n = nextToken().toInt()
+        m = nextToken().toInt()
+    }
+
+    val arr = IntArray(n + 1)
+    for (i in 1..n) {
+        arr[i] = br.readLine().toInt()
+    }
+
+    val minSeg = MinSeg(n).apply { init(arr) }
+    val maxSeg = MaxSeg(n).apply { init(arr) }
+
+    repeat(m) {
+        val min: Int
+        val max: Int
+        StringTokenizer(br.readLine()).run {
+            val left = nextToken().toInt()
+            val right = nextToken().toInt()
+
+            min = minSeg.findRangeMin(left, right)
+            max = maxSeg.findRangeMax(left, right)
+        }
+
+        bw.write("$min $max")
+        bw.newLine()
+    }
+
+    bw.close()
+    br.close()
+}
+
+private class MinSeg(private val n: Int) {
+    private val minSeg = IntArray(n * 4)
+
+    fun init(arr: IntArray, start: Int = 1, end: Int = n, node: Int = 1): Int {
+        if (start == end) {
+            minSeg[node] = arr[start]
+            return minSeg[node]
+        }
+
+        val mid = (start + end) / 2
+
+        minSeg[node] = minOf(init(arr, start, mid, node * 2), init(arr, mid + 1, end, node * 2 + 1))
+        return minSeg[node]
+    }
+
+    fun findRangeMin(left: Int, right: Int, start: Int = 1, end: Int = n, node: Int = 1): Int {
+        if (right < start || left > end) {
+            return Int.MAX_VALUE
+        }
+
+        if (left <= start && end <= right) {
+            return minSeg[node]
+        }
+
+        val mid = (start + end) / 2
+
+        return minOf(
+            findRangeMin(left, right, start, mid, node * 2),
+            findRangeMin(left, right, mid + 1, end, node * 2 + 1)
+        )
+    }
+}
+
+private class MaxSeg(private val n: Int) {
+    private val maxSeg = IntArray(n * 4)
+
+    fun init(arr: IntArray, start: Int = 1, end: Int = n, node: Int = 1): Int {
+        if (start == end) {
+            maxSeg[node] = arr[start]
+            return maxSeg[node]
+        }
+
+        val mid = (start + end) / 2
+
+        maxSeg[node] = maxOf(init(arr, start, mid, node * 2), init(arr, mid + 1, end, node * 2 + 1))
+        return maxSeg[node]
+    }
+
+    fun findRangeMax(left: Int, right: Int, start: Int = 1, end: Int = n, node: Int = 1): Int {
+        if (right < start || left > end) {
+            return Int.MIN_VALUE
+        }
+
+        if (left <= start && end <= right) {
+            return maxSeg[node]
+        }
+
+        val mid = (start + end) / 2
+
+        return maxOf(
+            findRangeMax(left, right, start, mid, node * 2),
+            findRangeMax(left, right, mid + 1, end, node * 2 + 1)
+        )
+    }
+}

--- a/suho/withkotlin/src/main/kotlin/week12/b9466/B9466.kt
+++ b/suho/withkotlin/src/main/kotlin/week12/b9466/B9466.kt
@@ -1,0 +1,65 @@
+package baekjoon.b9466
+
+import java.util.*
+
+/*
+플랫폼 : 백준
+문제번호 : 9466
+문제제목 : 텀 프로젝트
+난이도 : 골드 3
+제한사항 : 3초/256MB
+알고리즘 분류 : 그래프 이론, 그래프 탐색, 깊이 우선 탐색
+
+알고리즘 설명
+위상정렬 사용 또는 DFS로 풀이 가능
+
+채점 결과 : 3224ms/333476KB
+풀이 날짜 : 2022/04/10
+*/
+
+private val br = System.`in`.bufferedReader()
+private val bw = System.out.bufferedWriter()
+
+fun main() {
+    repeat(br.readLine().toInt()) { _ ->
+        val n = br.readLine().toInt()
+        val graph = Array(n + 1) { mutableListOf<Int>() }
+        val inDegree = IntArray(n + 1)
+        with(StringTokenizer(br.readLine())) {
+            for (i in 1..n) {
+                val temp = nextToken().toInt()
+                graph[i].add(temp)
+                inDegree[temp]++
+            }
+        }
+
+        val queue = LinkedList<Int>()
+        for (i in 1..n) {
+            if (inDegree[i] == 0) {
+                queue.offer(i)
+            }
+        }
+
+        while (!queue.isEmpty()) {
+            val cur = queue.poll()
+
+            for (next in graph[cur]) {
+                inDegree[next]--
+
+                if (inDegree[next] == 0) {
+                    queue.offer(next)
+                }
+            }
+        }
+
+        var answer = 0
+        for (i in 1..n) {
+            if (inDegree[i] == 0) answer++
+        }
+
+        bw.write("$answer")
+        bw.newLine()
+    }
+    bw.close()
+    br.close()
+}


### PR DESCRIPTION
이번주에 풀었던 문제 중에 좋았던 문제 3개 공유합니다.

9466번 텀 프로젝트
주어진 문제를 그래프 관계로 표현할 수 있습니다.
그래프로 표현하면 학생 -> 같이 팀이 되길 원하는 학생의 단방향 간선으로 표현할 수 있습니다.
같은 팀이 되는 관계는 그래프에서 사이클을 이루는 정점끼리 같은 팀이 됩니다.
사이클을 이루는 정점을 확인하는 방법은 2가지가 있는데 DFS와 위상정렬을 사용해서 풀 수 있습니다.
DFS를 사용해서 푸는 경우 한 번 방문했던 정점을 다시 방문한 경우 사이클이 이루어지고 위상정렬을 사용해서 푸는 경우 종료 후에 진입 차수가 0이 아닌 정점들이 사이클을 이루는 정점이 됩니다.
문제의 정답은 사이클을 이루지 않는 정점 수를 구하면 됩니다.

13334번 철로
입력을 왼쪽 끝 점, 오른쪽 끝 점 형태의 Pair로 입력받습니다.
철로 리스트를 오른쪽 끝 점을 기준으로 정렬합니다. 같은 경우 왼쪽 끝 점이 정렬 기준이 됩니다.
최소 힙 우선순위 큐를 하나 만듭니다.
정렬된 리스트의 원소를 하나씩 관찰하면서, 철로의 길이(오른쪽 끝 점 - 왼쪽 끝 점)가 d이하이면 우선순위 큐에 왼쪽 끝 점을 삽입합니다.
우선순위 큐에는 각 철로의 왼쪽 끝 점들이 담기게 됩니다. 위의 작업 후에 우선순위 큐에 원소가 존재하면 front를 하나씩 보면서, (현재 관찰중인 오른쪽 끝 점 - front)가 d를 초과하면 우선순위 큐에서 제거합니다.
위 작업이 끝나면 우선순위 큐의 크기와 정답을 둘 중의 최대값으로 계속 갱신해줍니다.

2357번 최솟값과 최댓값
세그먼트 트리 아이디어를 이용합니다.
모든 구간에 대해 완전탐색을 사용하면 시간초과가 발생하므로 세그먼트 트리를 이용합니다.
세그먼트 트리가 구간합에 대한 정보를 저장했었다면, 구간의 최솟값과 최댓값을 구할 수 있는 세그먼트 트리로 변형해서 만듭니다.
입력 케이스에 맞게 구간의 최솟값과 최댓값을 찾으면 됩니다.