### PR TITLE
[Solve] 이분탐색 - 가장 긴 증가하는 부분 수열 5

### DIFF
--- a/yoongyeong/by_kotlin/src/main/kotlin/binarysearch_parametricsearch/B14003.kt
+++ b/yoongyeong/by_kotlin/src/main/kotlin/binarysearch_parametricsearch/B14003.kt
@@ -1,0 +1,62 @@
+package binarysearch_parametricsearch
+
+import java.util.StringTokenizer
+
+// 가장 긴 증가하는 부분 수열 5
+
+fun main() {
+    val br = System.`in`.bufferedReader()
+    val bw = System.out.bufferedWriter()
+    val n = br.readLine().toInt()
+
+    val array = IntArray(n+1)
+    val dp = Array(n+1) { IntArray(2) }
+    val trace = IntArray(n+1)
+
+    var end = 0
+    val token = StringTokenizer(br.readLine())
+
+    dp[0][0] = Int.MIN_VALUE
+    dp[0][1] = -1
+
+    for (x in 1 .. n) {
+        array[x] = token.nextToken().toInt()
+
+        var start = 0
+        var newEnd = end
+
+        while (start < newEnd) {
+            val mid = (start+newEnd) / 2
+
+            if (dp[mid][0] >= array[x]) newEnd = mid
+            else start = mid+1
+        }
+
+        if (end == newEnd && dp[end][0] < array[x]) {
+            end++; newEnd++
+        }
+
+        dp[newEnd][0] = array[x]
+        dp[newEnd][1] = x
+        trace[x] = dp[newEnd - 1][1]
+
+    }
+
+    bw.write("$end\n")
+
+    var last = dp[end][1]
+    val answer = IntArray(end)
+
+    for (x in end-1 downTo 0) {
+        answer[x] = array[last]
+        last = trace[last]
+    }
+
+    for (x in 0 until end) {
+        bw.write("${answer[x]} ")
+    }
+
+    bw.close()
+    br.close()
+
+}


### PR DESCRIPTION
이분탐색을 이용해서 배열에 저장을 해둡니다. 이때 순서가 정렬되어 있는 상태(기존 배열과 순서가 다름)로 나오게 됩니다.
따라서 역추적을 하여 증가하는 수열을 만들기 위하여 역추적을 하여 출력하는 방식으로 문제를 풀었습니다.
dp 배열에서 dp[][0]은 이분탐색을 이용하여 나온 수열의 수를 dp[][1]은 인덱스를 저장하여 
이후에 추적할 수 있도록 하였습니다