### PR TITLE
[Solve] 수학 - 약수의 합

### DIFF
--- a/jaeseuk/kokotlin/src/main/kotlin/boj/code_plus1/B17425.kt
+++ b/jaeseuk/kokotlin/src/main/kotlin/boj/code_plus1/B17425.kt
@@ -1,0 +1,36 @@
+package boj.code_plus1
+
+import java.io.BufferedReader
+import java.io.BufferedWriter
+import java.io.InputStreamReader
+import java.io.OutputStreamWriter
+
+//  약수의 합
+
+fun main() {
+    val br = BufferedReader(InputStreamReader(System.`in`))
+    val bw = BufferedWriter(OutputStreamWriter(System.out))
+
+    val g = LongArray(1_000_001) { 1 }
+
+    for (i in 2..1_000_000) {
+        var j = 1
+
+        while (i * j <= 1_000_000) {
+            g[i * j] = g[i * j] + i
+            j++
+        }
+    }
+
+    for (i in 2..1_000_000) {
+        g[i] += g[i - 1]
+    }
+
+    repeat(br.readLine().toInt()) {
+        bw.write("${g[br.readLine().toInt()]}")
+        bw.newLine()
+    }
+
+    bw.flush()
+    bw.close()
+}


### PR DESCRIPTION
1. 배열 요소를 1로 초기화
2. 최댓값이 1,000,000이므로 2부터 1,000,000까지 해당 숫자의 배수 인덱스에 해당 숫자를 더해준다.
3. 위 작업으로 f(a) 값들이 구해졌으므로 누적합을 구하면 각 인덱스의 요소들의 값은 g(a)가 된다.
4. 각 테스트 케이스마다 입력 받은 n 위치의 요소를 출력한다.