### PR TITLE
[Solve] 누적합 - 구간 합 구하기 4

### DIFF
--- a/yoongyeong/by_kotlin/src/main/kotlin/twopointer_prefixsum/B11659.kt
+++ b/yoongyeong/by_kotlin/src/main/kotlin/twopointer_prefixsum/B11659.kt
@@ -1,0 +1,33 @@
+package twopointer_prefixsum
+
+import java.util.StringTokenizer
+
+// 구간 합 구하기 4
+
+fun main() {
+    val br = System.`in`.bufferedReader()
+    val bw = System.out.bufferedWriter()
+
+    val n: Int; val m: Int
+    with(StringTokenizer(br.readLine())) {
+        n = nextToken().toInt()
+        m = nextToken().toInt()
+    }
+    val dp = IntArray(n+1)
+    with(StringTokenizer(br.readLine())) {
+        for (index in 1 .. n) {
+            dp[index] = dp[index-1] + nextToken().toInt()
+        }
+    }
+
+    repeat(m) {
+        with(StringTokenizer(br.readLine())) {
+            val i = nextToken().toInt()
+            val j = nextToken().toInt()
+            bw.write("${dp[j] - dp[i-1]}\n")
+        }
+    }
+
+    bw.close()
+    br.close()
+}


### PR DESCRIPTION
누적합을 구하기 위해 dp 배열에 두고 이전까지의 합과 현재합을 계산해서 인덱스는 0부터 인덱스까지의 합을 저장할 수 있도록 하였습니다. 