### PR TITLE
[Solve] 일곱 난쟁이, 사탕 게임

### DIFF
--- a/jaeseuk/kokotlin/src/main/kotlin/boj/code_plus2/B2309.kt
+++ b/jaeseuk/kokotlin/src/main/kotlin/boj/code_plus2/B2309.kt
@@ -1,0 +1,38 @@
+package boj.code_plus2
+
+import java.io.BufferedReader
+import java.io.BufferedWriter
+import java.io.InputStreamReader
+import java.io.OutputStreamWriter
+import kotlin.system.exitProcess
+
+//  일곱 난쟁이
+
+private val br = BufferedReader(InputStreamReader(System.`in`))
+private val bw = BufferedWriter(OutputStreamWriter(System.out))
+
+private val heights = IntArray(9) { br.readLine().toInt() }.sortedArray()
+
+fun main() {
+    find(IntArray(7), 0, 0, 1)
+}
+
+private fun find(answer: IntArray, sum: Int, start: Int, step: Int) {
+
+    if (step > 7) {
+        if (sum == 100) {
+            bw.write(answer.joinToString("\n"))
+            bw.flush()
+            bw.close()
+            exitProcess(0)
+        }
+
+        return
+    }
+
+    for (i in start..heights.lastIndex) {
+        answer[step - 1] = heights[i]
+        find(answer, sum + heights[i], i + 1, step + 1)
+        answer[step - 1] = 0
+    }
+}

--- a/jaeseuk/kokotlin/src/main/kotlin/boj/code_plus2/B3085.kt
+++ b/jaeseuk/kokotlin/src/main/kotlin/boj/code_plus2/B3085.kt
@@ -1,0 +1,90 @@
+package boj.code_plus2
+
+import java.io.BufferedReader
+import java.io.BufferedWriter
+import java.io.InputStreamReader
+import java.io.OutputStreamWriter
+
+//  사탕 게임
+
+private val br = BufferedReader(InputStreamReader(System.`in`))
+private val bw = BufferedWriter(OutputStreamWriter(System.out))
+
+private val n = br.readLine().toInt()
+private val board = Array(n) { br.readLine().toCharArray() }
+
+private var answer = 0
+
+fun main() {
+    val dx = intArrayOf(0, 1)
+    val dy = intArrayOf(1, 0)
+
+    for (i in 0 until n) {
+        for (j in 0 until n) {
+            repeat(2) {
+                val nx = i + dx[it]
+                val ny = j + dy[it]
+
+                if (nx < n && ny < n) {
+                    board[i][j] = board[nx][ny].also { board[nx][ny] = board[i][j] }
+                    calc(i, j, nx, ny)
+                    board[i][j] = board[nx][ny].also { board[nx][ny] = board[i][j] }
+                }
+            }
+        }
+    }
+
+    bw.write("$answer")
+    bw.flush()
+    bw.close()
+}
+
+private fun calc(x: Int, y: Int, nx:Int, ny:Int) {
+    if (x < nx) {
+        colCalc(y)
+        rowCalc(x)
+        rowCalc(nx)
+    } else {
+        rowCalc(x)
+        colCalc(y)
+        colCalc(ny)
+    }
+}
+
+private fun colCalc(y: Int) {
+    var ch = board[0][y]
+    var cnt = 1
+    var maxCnt = 0
+
+    for (i in 1 until n) {
+        if (ch == board[i][y]) {
+            cnt++
+        } else {
+            maxCnt = maxOf(maxCnt, cnt)
+            cnt = 1
+            ch = board[i][y]
+        }
+    }
+
+    maxCnt = maxOf(maxCnt, cnt)
+    answer = maxOf(answer, maxCnt)
+}
+
+private fun rowCalc(x: Int) {
+    var ch = board[x][0]
+    var cnt = 1
+    var maxCnt = 0
+
+    for (i in 1 until n) {
+        if (ch == board[x][i]) {
+            cnt++
+        } else {
+            maxCnt = maxOf(maxCnt, cnt)
+            cnt = 1
+            ch = board[x][i]
+        }
+    }
+
+    maxCnt = maxOf(maxCnt, cnt)
+    answer = maxOf(answer, maxCnt)
+}


### PR DESCRIPTION
1. 일곱 난쟁이(2309):
- 7개 요소의 합이 100이 되는 경우를 오름차순으로 출력하면 되는 문제.
- 생각이 잘 안나서 백트래킹으로 풀었습니다.

2. 사탕 게임(3085):
- 보드 위의 칸 2개를 서로 바꾼 뒤 같은 색으로 이루어져 있는 가장 긴 연속 행 또는 열의 길이를 출력하는 문제.
- 모든 칸을 순회하면서 오른쪽 칸과 교환하는 경우와 아래 칸과 교환하는 경우를 범위 체크 후 각각 교환하고 계산을 수행.
- 계산은 아래 칸과 교환했을 경우 해당 열과 교환한 두 칸의 행을 확인한다.
- 오른쪽 칸과 교환했을 경우 해당 행과 교환한 두 칸의 열을 확인한다.
- 위 작업이 다 끝나면 교환했던 칸들을 다시 교환하고 다음 칸으로 넘어간다. 