### PR TITLE
[Solve] 우선순위 큐 - 절댓값 힙

### DIFF
--- a/yoongyeong/by_kotlin/src/main/kotlin/stack_queue/B11286.kt
+++ b/yoongyeong/by_kotlin/src/main/kotlin/stack_queue/B11286.kt
@@ -1,0 +1,39 @@
+package stack_queue
+
+import java.util.PriorityQueue
+
+// 절댓값 힙
+
+fun main() {
+    val br = System.`in`.bufferedReader()
+    val bw = System.out.bufferedWriter()
+
+    val plus = PriorityQueue<Int>()
+    val minus = PriorityQueue<Int>()
+
+    val n = br.readLine().toInt()
+    for (i in 0 until n) {
+        val x = br.readLine().toInt()
+        if (x == 0) {
+            val p = plus.peek()  ?: 0
+            val m = minus.peek() ?: 0
+            bw.write("${when {
+                p == 0 && m == 0 -> 0
+                p == 0 -> -minus.poll()
+                m == 0 -> plus.poll()
+                p < m -> plus.poll()
+                else -> -minus.poll()
+            }}\n")
+        } else {
+            if (x > 0) {
+                plus.add(x)
+            } else {
+                minus.add(-x)
+            }
+        }
+
+    }
+
+    bw.close()
+    br.close()
+}


### PR DESCRIPTION
양수의 우선순위 큐와 음수의 우선순위 큐를 만들어서 각각 저장했습니다. 이때 음수의 절댓값끼리 비교를 해야되므로 양수로 전환시켜 저장시켜주었습니다.
이외에는 문제의 조건을 그대로 구현하였습니다.